### PR TITLE
Issue 70 idt huge fixations

### DIFF
--- a/Options.qml
+++ b/Options.qml
@@ -45,7 +45,7 @@ Popup {
         if(algSelection.currentIndex === 0) {
             rtn = rtn + "-" + windowSize.text + "-" + radius.text + "-" + peak.text
         } else if (algSelection.currentIndex === 1) {
-            rtn = rtn + "-" + durationWindow.text + "-" + dispersion.text
+            rtn = rtn + "-" + durationWindow.text + "-" + dispersion.text + "-" + maxGazeSpan.text
         } else if (algSelection.currentIndex === 2) {
             rtn = rtn + "-" + velocity.text + "-" + duration.text
         }
@@ -157,14 +157,14 @@ Popup {
 
         Text {
             id: durationWindowLabel
-            text: qsTr("Duration Window: ")
+            text: qsTr("Duration Window (ms): ")
         }
         TextField {
             id: durationWindow
             Layout.fillWidth: true
             //Int validator requires input to be a number >1 and <MAXINT
             validator: IntValidator {bottom: 1}
-            readonly property string defaultVal: "10"
+            readonly property string defaultVal: "100"
             text: defaultVal
         }
         Text {
@@ -176,6 +176,17 @@ Popup {
             Layout.fillWidth: true
             validator: IntValidator{bottom: 1}
             readonly property string defaultVal: "125"
+            text: defaultVal
+        }
+        Text {
+            id: maxGazeSpanLabel
+            text: qsTr("Maximum Gaze Span (ms): ")
+        }
+        TextField {
+            id: maxGazeSpan
+            Layout.fillWidth: true
+            validator: IntValidator{bottom: 1}
+            readonly property string defaultVal: "1000"
             text: defaultVal
         }
         Item {
@@ -249,6 +260,7 @@ Popup {
                 //IDT Algorithm Reset
                 durationWindow.text = durationWindow.defaultVal
                 dispersion.text = dispersion.defaultVal
+                maxGazeSpan.text = maxGazeSpan.defaultVal
 
                 //IVT Algorithm Reset
                 velocity.text = velocity.defaultVal

--- a/controller.cpp
+++ b/controller.cpp
@@ -449,7 +449,7 @@ void Controller::generateFixationData(QVector<QString> tasks, QString algSetting
             }
             else if(settings[0] == "IDT") {
                 //IDT-10-125 = IDT-duration_window-dispersion
-                algorithm = new IDTAlgorithm(gazes,settings[duration_window].toInt(),settings[dispersion].toInt());
+                algorithm = new IDTAlgorithm(gazes,settings[duration_window].toInt(),settings[dispersion].toInt(),settings[max_gaze_span].toInt());
             }
             else if(settings[0] == "IVT") {
                 //IVT-50-80 = IVT-velocity-duration

--- a/controller.h
+++ b/controller.h
@@ -51,7 +51,8 @@ enum basic {
 
 enum idt {
     duration_window = 1,
-    dispersion
+    dispersion,
+    max_gaze_span
 };
 
 enum ivt {

--- a/idtalgorithm.cpp
+++ b/idtalgorithm.cpp
@@ -32,43 +32,68 @@ QVector<Fixation> IDTAlgorithm::generateFixations() {
 
     //This code follows the IDT Algorithm
 
-    //Step 1 should already be done
-
-    //Step 2 - Calculate velocity between each point and generate Fixations
-    QVector<Gaze> window;
-    int i = 0;
-
-    while(i < duration_window && i < session_gazes.size()) {
-        window.push_back(session_gazes[i]);
-        ++i;
-    }
-
-    while(i < session_gazes.size()) {
-        if((computeGazeDifference(window) <= dispersion) && (window.size() >= duration_window)) {
-            while(computeGazeDifference(window) <= dispersion) {
-                if(i < session_gazes.size() - 1) {
-                    window.push_back(session_gazes[i]);
-                    ++i;
-                }
-                else { break; }
-            }
-            fixations.push_back(computeFixationEstimate(window));
-            window.clear();
+    //QVector<Gaze> window;
+    while(session_gazes.size() != 0) { // While there are still points
+        // Initialize the window over the first points to not cover the duration threshold
+        QVector<Gaze> window;
+        int i = 0;
+        while(window.size() != duration_window && session_gazes.size() != 0) {
             window.push_back(session_gazes[i]);
             ++i;
         }
-        else if(window.size() < duration_window) {
-            window.push_back(session_gazes[i]);
-            ++i;
-        }
-        else {
-            window.pop_front();
-            if(window.size() < duration_window) {
+
+        // If dispersion of window points <= threshold
+        if(computeGazeDifference(window) <= dispersion) {
+            // Add additional points to the window until dispersion > threshold
+            while(computeGazeDifference(window) <= dispersion && i < session_gazes.size()) {
                 window.push_back(session_gazes[i]);
                 ++i;
             }
+            // Not a fixation ant the centroid of the windows points
+            fixations.push_back(computeFixationEstimate(window));
+            // Remove window points from points
+            for(int x = 0; x < window.size(); ++x) {
+                session_gazes.pop_front();
+            }
+        }
+        else {
+           session_gazes.pop_front();
         }
     }
+//    QVector<Gaze> window;
+//    int i = 0;
+
+//    while(i < duration_window && i < session_gazes.size()) {
+//        window.push_back(session_gazes[i]);
+//        ++i;
+//    }
+
+//    while(i < session_gazes.size()) {
+//        if((computeGazeDifference(window) <= dispersion) && (window.size() >= duration_window)) {
+//            while(computeGazeDifference(window) <= dispersion) {
+//                if(i < session_gazes.size() - 1) {
+//                    window.push_back(session_gazes[i]);
+//                    ++i;
+//                }
+//                else { break; }
+//            }
+//            fixations.push_back(computeFixationEstimate(window));
+//            window.clear();
+//            window.push_back(session_gazes[i]);
+//            ++i;
+//        }
+//        else if(window.size() < duration_window) {
+//            window.push_back(session_gazes[i]);
+//            ++i;
+//        }
+//        else {
+//            window.pop_front();
+//            if(window.size() < duration_window) {
+//                window.push_back(session_gazes[i]);
+//                ++i;
+//            }
+//        }
+//    }
 
     return fixations;
 }

--- a/idtalgorithm.h
+++ b/idtalgorithm.h
@@ -16,7 +16,7 @@
 
 class IDTAlgorithm : public FixationAlgorithm{
 public:
-    IDTAlgorithm(QVector<Gaze> gazes, int _duration, int _dispersion);
+    IDTAlgorithm(QVector<Gaze> gazes, int _duration, int _dispersion, int _max_gaze_span);
     ~IDTAlgorithm() {};
 
     QVector<Fixation> generateFixations() override;
@@ -27,6 +27,7 @@ private:
 
     int duration_window;
     int dispersion;
+    int max_gaze_span;
 };
 
 #endif // IDTALGORITHM_H


### PR DESCRIPTION
IDT algorithm has been fixed. There is a new parameter, Max Gaze Span, which determines the maximum possible gap between any two gazes in the window. By default it is set to 1000 - meaning that if a participant looks look-screen for more than 1 second, no fixation will "bridge" the off-screen gap. This also helps by allowing fixations that are close to the screen age still form, even if 1 or 2 gazes happen to wiggle off the screen.

The algorithm should be tested to ensure there are no longer any large fixations.

Fixes Issue 70